### PR TITLE
NL #89 - Additional layers

### DIFF
--- a/src/Entity/NeatlineExhibit.php
+++ b/src/Entity/NeatlineExhibit.php
@@ -253,7 +253,9 @@ class NeatlineExhibit extends AbstractEntity
 
     public function getSpatialLayers()
     {
-        return array_filter(explode(",", $this->spatial_layers));
+        return array_filter(explode(",", $this->spatial_layers), function ($val) {
+          return $val !== NULL && $val !== '';
+        });
     }
 
     public function setSpatialLayer($spatial_layer)


### PR DESCRIPTION
This pull request adjusts the `NeatlineExhibit#getSpatialLayers` function to use a custom callback to filter out empty values. The standard callback use a "truth" test to determine if values are empty, and values like `0` and `"0"` do not pass the truth test, but correspond to legitimate values.